### PR TITLE
Chore: Perform needed renames for moving Github organizations to awsteam

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ about: Create a report to help us improve
 
 ## Prerequisites
 
-Please Check that your issue isn't already filed: [Open Issues](https://github.com/brittandeyoung/terraform-provider-awsteam/issues)
+Please Check that your issue isn't already filed: [Open Issues](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues)
 
 ## Description
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,48 +20,48 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### New
 
-* DataSource: `awsteam_accounts` [#44](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/44)
+* DataSource: `awsteam_accounts` [#44](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/44)
 
 ### Fixes
 
-* Resource: `awsteam_settings` - resolved update flow failing to set computed values [#41](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/41)
+* Resource: `awsteam_settings` - resolved update flow failing to set computed values [#41](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/41)
 
 ## 1.0.1 - (2024-03-05)
 ---
 
 ### Fixes
 
-* Resource: `awsteam_eligibility_group` now requires the `group_id` field. This will be used as the resource `id`. [36](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/36)
-* Resource: `awsteam_eligibility_user` now requires the `user_id` field. This will be used as the resource `id`. [36](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/36)
+* Resource: `awsteam_eligibility_group` now requires the `group_id` field. This will be used as the resource `id`. [36](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/36)
+* Resource: `awsteam_eligibility_user` now requires the `user_id` field. This will be used as the resource `id`. [36](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/36)
 * Resources: `awsteam_eligibility_group`, `awsteam_eligibility_user`, `awsteam_approvers_account`, `awsteam_approvers_ou`, and `awsteam_settings` Deleting outside of terraform will no longer cause terraform to error.
 
 ## 1.0.0 - (2024-02-27)
 
 ### Changes
 
-* Removed validators on `group_id` schema fields as they can be values other than UUID [26](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/26)
+* Removed validators on `group_id` schema fields as they can be values other than UUID [26](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/26)
 
 ### Fixes
 
-* Provider: Corrected the provider schema attribute mapping to configuration fields for `client_secret`, `graph_endpoint`, and `token_endpoint` [24](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/24)
+* Provider: Corrected the provider schema attribute mapping to configuration fields for `client_secret`, `graph_endpoint`, and `token_endpoint` [24](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/24)
 
 ### Breaks
 
-* Resources: `awsteam_eligibility_group`, `awsteam_eligibility_user`, and `awsteam_approvers_account` AWS account numbers are now string values [26](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/26)
+* Resources: `awsteam_eligibility_group`, `awsteam_eligibility_user`, and `awsteam_approvers_account` AWS account numbers are now string values [26](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/26)
 
 
 ## 0.2.0 - (2024-01-17)
 
 ### New
 
-* Resource: `awsteam_eligibility_group` [#8](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/8)
-* Resource: `awsteam_eligibility_user` [#8](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/8)
+* Resource: `awsteam_eligibility_group` [#8](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/8)
+* Resource: `awsteam_eligibility_user` [#8](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/8)
 
 ## 0.1.0 - (2024-01-12)
 
 ### New
 
-* Resource: `awsteam_approvers_account` [#7](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/7)
-* Resource: `awsteam_approvers_ou` [#7](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/7)
-* DataSource: `awsteam_settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)
-* Resource: `awsteam_settings` [#4](https://github.com/brittandeyoung/terraform-provider-awsteam/issues/4)
+* Resource: `awsteam_approvers_account` [#7](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/7)
+* Resource: `awsteam_approvers_ou` [#7](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/7)
+* DataSource: `awsteam_settings` [#4](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/4)
+* Resource: `awsteam_settings` [#4](https://github.com/awsteam-contrib/terraform-provider-awsteam/issues/4)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Terraform Provider awsteam
 
-The [AWS TEAM Provider](https://registry.terraform.io/providers/brittandeyoung/awsteam/latest/docs) allows [Terraform](https://terraform.io) to manage [AWS TEAM](https://github.com/aws-samples/iam-identity-center-team) resources.
+The [AWS TEAM Provider](https://registry.terraform.io/providers/awsteam-contrib/awsteam/latest/docs) allows [Terraform](https://terraform.io) to manage [AWS TEAM](https://github.com/aws-samples/iam-identity-center-team) resources.
 
 - [Contributing guide](CONTRIBUTING.md)

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/brittandeyoung/terraform-provider-awsteam
+module github.com/awsteam-contrib/terraform-provider-awsteam
 
 go 1.23.0
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/envvar"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/envvar"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 )
 
 // These two functions come form the terraform-provider-aws code

--- a/internal/provider/accounts_data_source.go
+++ b/internal/provider/accounts_data_source.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"

--- a/internal/provider/approvers_account.go
+++ b/internal/provider/approvers_account.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/smithy-go/ptr"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/names"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/names"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/internal/provider/approvers_ou.go
+++ b/internal/provider/approvers_ou.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/smithy-go/ptr"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/names"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/names"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 	"github.com/hashicorp/terraform-plugin-framework-validators/setvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/internal/provider/eligibility.go
+++ b/internal/provider/eligibility.go
@@ -2,7 +2,7 @@ package provider
 
 import (
 	"github.com/YakDriver/regexache"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"

--- a/internal/provider/eligibility_group.go
+++ b/internal/provider/eligibility_group.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/smithy-go/ptr"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/names"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/names"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/eligibility_test.go
+++ b/internal/provider/eligibility_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 
 	"github.com/aws/smithy-go/ptr"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/acctest"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/acctest"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 )

--- a/internal/provider/eligibility_user.go
+++ b/internal/provider/eligibility_user.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/YakDriver/regexache"
 	"github.com/aws/smithy-go/ptr"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/names"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/names"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,8 +8,8 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/envvar"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/envvar"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/provider"
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"

--- a/internal/provider/settings.go
+++ b/internal/provider/settings.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/names"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/names"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"

--- a/internal/provider/settings_data_source.go
+++ b/internal/provider/settings_data_source.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/names"
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/sdk/awsteam"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/names"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-log/tflog"

--- a/internal/provider/settings_test.go
+++ b/internal/provider/settings_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/acctest"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/acctest"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/brittandeyoung/terraform-provider-awsteam/internal/provider"
+	"github.com/awsteam-contrib/terraform-provider-awsteam/internal/provider"
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 )
 
@@ -35,8 +35,7 @@ func main() {
 	flag.Parse()
 
 	opts := providerserver.ServeOpts{
-		// TODO: Update this string with the published name of your provider.
-		Address: "registry.terraform.io/brittandeyoung/awsteam",
+		Address: "registry.terraform.io/awsteam-contrib/awsteam",
 		Debug:   debug,
 	}
 


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR performs the necessary renaming within files since the project has moved to the new `awsteam-contrib` organization.

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Running Acceptance Tests
<!--
Output from Acceptance tests to test the new feature or fix.
-->

```
$  make testacc
$ make testacc
TF_ACC=1 go test ./... -v "-run=TestAcc" -timeout 120m
?       github.com/awsteam-contrib/terraform-provider-awsteam   [no test files]
?       github.com/awsteam-contrib/terraform-provider-awsteam/internal/acctest  [no test files]
?       github.com/awsteam-contrib/terraform-provider-awsteam/internal/envvar   [no test files]
?       github.com/awsteam-contrib/terraform-provider-awsteam/internal/names    [no test files]
?       github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam      [no test files]
=== RUN   TestAccAccountsDataSource_basic
    accounts_data_source_test.go:17: Skipping Accounts Tests, Environment variable AWSTEAM_TESTS_EXPECTED_ACCOUNTS_COUNT is not set.
--- SKIP: TestAccAccountsDataSource_basic (0.00s)
=== RUN   TestAccApproversAccountResource_basic
--- PASS: TestAccApproversAccountResource_basic (4.96s)
=== RUN   TestAccApproversAccountResource_accountId
--- PASS: TestAccApproversAccountResource_accountId (2.30s)
=== RUN   TestAccApproversOUResource_basic
--- PASS: TestAccApproversOUResource_basic (3.77s)
=== RUN   TestAccEligibilityGroupResource_basic
--- PASS: TestAccEligibilityGroupResource_basic (4.28s)
=== RUN   TestAccEligibilityGroupResource_missingAccountsAndOUs
--- PASS: TestAccEligibilityGroupResource_missingAccountsAndOUs (0.28s)
=== RUN   TestAccEligibilityGroupResource_missingAccounts
--- PASS: TestAccEligibilityGroupResource_missingAccounts (2.66s)
=== RUN   TestAccEligibilityGroupResource_missingOUs
--- PASS: TestAccEligibilityGroupResource_missingOUs (2.54s)
=== RUN   TestAccEligibilityGroupResource_emptyAccounts
--- PASS: TestAccEligibilityGroupResource_emptyAccounts (2.79s)
=== RUN   TestAccEligibilityGroupResource_emptyOUs
--- PASS: TestAccEligibilityGroupResource_emptyOUs (2.68s)
=== RUN   TestAccEligibilityGroupResource_Accounts
--- PASS: TestAccEligibilityGroupResource_Accounts (2.59s)
=== RUN   TestAccEligibilityGroupResource_disappears
--- PASS: TestAccEligibilityGroupResource_disappears (2.36s)
=== RUN   TestAccEligibilityUserResource_basic
--- PASS: TestAccEligibilityUserResource_basic (4.45s)
=== RUN   TestAccEligibilityUserResource_missingAccountsAndOUs
--- PASS: TestAccEligibilityUserResource_missingAccountsAndOUs (0.26s)
=== RUN   TestAccEligibilityUserResource_missingAccounts
--- PASS: TestAccEligibilityUserResource_missingAccounts (2.60s)
=== RUN   TestAccEligibilityUserResource_missingOUs
--- PASS: TestAccEligibilityUserResource_missingOUs (2.78s)
=== RUN   TestAccEligibilityUserResource_emptyAccounts
--- PASS: TestAccEligibilityUserResource_emptyAccounts (2.70s)
=== RUN   TestAccEligibilityUserResource_emptyOUs
--- PASS: TestAccEligibilityUserResource_emptyOUs (2.46s)
=== RUN   TestAccEligibilityUserResource_disappears
--- PASS: TestAccEligibilityUserResource_disappears (2.43s)
=== RUN   TestAccSettings_serial
=== PAUSE TestAccSettings_serial
=== CONT  TestAccSettings_serial
    settings_test.go:23: Skipping Settings Tests, Environment variable AWSTEAM_RUN_SETTINGS_TESTS is not set to true
--- SKIP: TestAccSettings_serial (0.00s)
PASS
ok      github.com/awsteam-contrib/terraform-provider-awsteam/internal/provider (cached)
...
```