### PR TITLE
Bugfix: Allow `unknown` values for ous or accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Breaks
 
+## 1.1.2 - (2025-04-16)
+
+### Fixes
+
+* Resource: `awsteam_eligibility_group` - Validation rule to ensure a single value is provided for `accounts` or `ous` now allows `unknown` values.
+* Resource: `awsteam_eligibility_user` - Validation rule to ensure a single value is provided for `accounts` or `ous` now allows `unknown` values.
+
 ## 1.1.1 - (2025-04-15)
 
 ### Changes

--- a/internal/provider/eligibility_group.go
+++ b/internal/provider/eligibility_group.go
@@ -121,7 +121,7 @@ func (r *EligibilityGroupResource) ValidateConfig(ctx context.Context, req resou
 		return
 	}
 
-	if len(config.Accounts.Elements()) == 0 && len(config.OUs.Elements()) == 0 {
+	if !config.Accounts.IsUnknown() && len(config.Accounts.Elements()) == 0 && len(config.OUs.Elements()) == 0 && !config.OUs.IsUnknown() {
 		resp.Diagnostics.AddError(
 			accountsAndOUsRequiredMessageSummary,
 			accountsAndOUsRequiredMessageDetail,

--- a/internal/provider/eligibility_user.go
+++ b/internal/provider/eligibility_user.go
@@ -121,7 +121,7 @@ func (r *EligibilityUserResource) ValidateConfig(ctx context.Context, req resour
 		return
 	}
 
-	if len(config.Accounts.Elements()) == 0 && len(config.OUs.Elements()) == 0 {
+	if !config.Accounts.IsUnknown() && len(config.Accounts.Elements()) == 0 && len(config.OUs.Elements()) == 0 && !config.OUs.IsUnknown() {
 		resp.Diagnostics.AddError(
 			accountsAndOUsRequiredMessageSummary,
 			accountsAndOUsRequiredMessageDetail,


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR resolves the issue with the current config validators that ensure you provide a single `account` or `ou`. If these values are `uknown` they are being treated as empty. The validation rules have been updated to allow for `unknown` values. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Running Acceptance Tests
<!--
Output from Acceptance tests to test the new feature or fix.
-->

```
✗ make testacc
TF_ACC=1 go test ./... -v "-run=TestAcc" -timeout 120m
?       github.com/awsteam-contrib/terraform-provider-awsteam   [no test files]
?       github.com/awsteam-contrib/terraform-provider-awsteam/internal/acctest  [no test files]
?       github.com/awsteam-contrib/terraform-provider-awsteam/internal/envvar   [no test files]
?       github.com/awsteam-contrib/terraform-provider-awsteam/internal/names    [no test files]
?       github.com/awsteam-contrib/terraform-provider-awsteam/internal/sdk/awsteam      [no test files]
=== RUN   TestAccAccountsDataSource_basic
    accounts_data_source_test.go:17: Skipping Accounts Tests, Environment variable AWSTEAM_TESTS_EXPECTED_ACCOUNTS_COUNT is not set.
--- SKIP: TestAccAccountsDataSource_basic (0.00s)
=== RUN   TestAccApproversAccountResource_basic
--- PASS: TestAccApproversAccountResource_basic (5.13s)
=== RUN   TestAccApproversAccountResource_accountId
--- PASS: TestAccApproversAccountResource_accountId (3.47s)
=== RUN   TestAccApproversOUResource_basic
--- PASS: TestAccApproversOUResource_basic (4.59s)
=== RUN   TestAccEligibilityGroupResource_basic
--- PASS: TestAccEligibilityGroupResource_basic (4.40s)
=== RUN   TestAccEligibilityGroupResource_missingAccountsAndOUs
--- PASS: TestAccEligibilityGroupResource_missingAccountsAndOUs (0.27s)
=== RUN   TestAccEligibilityGroupResource_missingAccounts
--- PASS: TestAccEligibilityGroupResource_missingAccounts (2.71s)
=== RUN   TestAccEligibilityGroupResource_missingOUs
--- PASS: TestAccEligibilityGroupResource_missingOUs (2.81s)
=== RUN   TestAccEligibilityGroupResource_emptyAccounts
--- PASS: TestAccEligibilityGroupResource_emptyAccounts (2.47s)
=== RUN   TestAccEligibilityGroupResource_emptyOUs
--- PASS: TestAccEligibilityGroupResource_emptyOUs (2.61s)
=== RUN   TestAccEligibilityGroupResource_Accounts
--- PASS: TestAccEligibilityGroupResource_Accounts (2.73s)
=== RUN   TestAccEligibilityGroupResource_disappears
--- PASS: TestAccEligibilityGroupResource_disappears (2.45s)
=== RUN   TestAccEligibilityUserResource_basic
--- PASS: TestAccEligibilityUserResource_basic (4.02s)
=== RUN   TestAccEligibilityUserResource_missingAccountsAndOUs
--- PASS: TestAccEligibilityUserResource_missingAccountsAndOUs (0.28s)
=== RUN   TestAccEligibilityUserResource_missingAccounts
--- PASS: TestAccEligibilityUserResource_missingAccounts (2.46s)
=== RUN   TestAccEligibilityUserResource_missingOUs
--- PASS: TestAccEligibilityUserResource_missingOUs (2.50s)
=== RUN   TestAccEligibilityUserResource_emptyAccounts
--- PASS: TestAccEligibilityUserResource_emptyAccounts (2.50s)
=== RUN   TestAccEligibilityUserResource_emptyOUs
--- PASS: TestAccEligibilityUserResource_emptyOUs (2.45s)
=== RUN   TestAccEligibilityUserResource_disappears
--- PASS: TestAccEligibilityUserResource_disappears (2.43s)
=== RUN   TestAccSettings_serial
=== PAUSE TestAccSettings_serial
=== CONT  TestAccSettings_serial
    settings_test.go:23: Skipping Settings Tests, Environment variable AWSTEAM_RUN_SETTINGS_TESTS is not set to true
--- SKIP: TestAccSettings_serial (0.00s)
PASS
ok      github.com/awsteam-contrib/terraform-provider-awsteam/internal/provider 50.702s

...
```